### PR TITLE
add `skipCacheDelete` flag to scoped directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install --save scoped-require
 ```js
 var scopedRequire = require('scoped-require');
 
-var baseModule = scopedRequire(['dir-with-module']);
+var baseModule = scopedRequire([{ path: 'dir-with-module' }]);
 
 var aModule = baseModule.require('a-module');
 
@@ -39,7 +39,7 @@ aModule = baseModule.require('a-module');
 
 ```
 
-Note thate creating the "scoped require" needs to be done after any other hooks to require,
+Note that creating the "scoped require" needs to be done after any other hooks to require,
 e.g. Traceur, babel, and others. This is because other hooks may not execute the original hook,
 but will rather override them.
 
@@ -52,8 +52,11 @@ The module exposes a factory returning a base module -
 
 ### `scopedRequire(scopedDirs, /*optional*/options)`:
 The parameters are:
-* `scopedDirs`: an array of directories (full or relative paths. If relative, they are relative to cwd).
+* `scopedDirs`: an array of objects representing the directories.
 These directories are the search path - any scoped require will search these directories, in the order they were given.
+Each directory is an object containing the following fields:
+  * `path` (required): the path of the directory (full or relative path. If relative, it is relative to cwd)
+  * `skipCacheDelete` (optional, default `false`): whether or not to skip deleting cache for modules inside this directory when `clearCache` is called.
 * `options`: an object with the following (optional) fields.
   * `autoDeleteCache`: every time `require` (see below) is called, it will also delete the cache, so that the
   next time `require` is called, the module will reload. Default: false.
@@ -61,7 +64,7 @@ These directories are the search path - any scoped require will search these dir
 Returns an object with the following method:
 * `require`: use this require to require any module which is in one of the `scopedDirs`
 * `loadCodeAsModule(content, filename)`: use this as an alternative to require, to load code that is dynamic.
-* `scopedDirs`: same array passed as an argument. If the dirs were relative, then this array will contain the absolute paths.
+* `scopedDirs`: The directory paths passed as an argument. If the paths were relative, then this array will contain the absolute paths.
 the `filename` is to make the errrors make sense.
 * `clearCache`: a method, that if called, will clear the module cache of all the modules
 already loaded from the `scopedDirs`. require-ing them again will reload them.

--- a/index.js
+++ b/index.js
@@ -6,16 +6,16 @@ const path = require('path')
 module.exports = function generateRequireForUserCode (scopedDirs, options) {
   options = _.defaults((options || {}), {autoDeleteCache: false})
 
-  scopedDirs = _.map(scopedDirs, function (dir) { return path.resolve(dir) })
+  const scopedDirsPaths = _.map(scopedDirs, function (scopedDir) { return path.resolve(scopedDir.path) })
 
   const baseModule = require('./lib/stubmodule-that-does-the-require')
   // so that it can be re-used again with another scoped-dir, I delete it from the cache
   delete Module._cache[baseModule.id]
   // make relative paths work when requiring
-  baseModule.filename = path.resolve(scopedDirs[0], 'stubmodule-that-does-the-require.js')
+  baseModule.filename = path.resolve(scopedDirsPaths[0], 'stubmodule-that-does-the-require.js')
 
   function addPaths (m) {
-    m.paths = _.uniq([...m.paths, ...scopedDirs])
+    m.paths = _.uniq([...m.paths, ...scopedDirsPaths])
   }
 
   addPaths(baseModule)
@@ -53,7 +53,7 @@ module.exports = function generateRequireForUserCode (scopedDirs, options) {
 
         return moduleExports
       },
-    scopedDirs: scopedDirs,
+    scopedDirs: scopedDirsPaths,
     clearCache: function () {
       deleteModuleFromCache(baseModule)
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scoped-require",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Require that is scoped to directories",
   "homepage": "https://github.com/wix/scoped-require",
   "author": {

--- a/test/scoped-dir/a-nested-scoped-dir/module-whose-load-side-effects-6.js
+++ b/test/scoped-dir/a-nested-scoped-dir/module-whose-load-side-effects-6.js
@@ -1,0 +1,1 @@
+global.moduleLoadSideEffect6++

--- a/test/scoped-dir/module-whose-load-side-effects-5.js
+++ b/test/scoped-dir/module-whose-load-side-effects-5.js
@@ -1,0 +1,1 @@
+global.moduleLoadSideEffect5++

--- a/test/test.js
+++ b/test/test.js
@@ -6,35 +6,35 @@ const path = require('path')
 
 describe('scoped-require node module', function () {
   it('must enable requiring from a directory that is not in the regular node path of this test', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
     const scopedModule = baseModule.require('scoped-module')
 
     assert.strictEqual(scopedModule.scopedFunction(), 'scopedString')
   })
 
   it('must support requiring a scoped dir from a non-scoped dir', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
     const unscopedModule = baseModule.require(path.resolve(__dirname, 'unscoped-dir/unscoped-module'))
 
     assert.strictEqual(unscopedModule.scopedFunction(), 'scopedString')
   })
 
   it('must support relative dirs', function () {
-    const baseModule = scopedRequire(['./test/scoped-dir'])
+    const baseModule = scopedRequire([{path: './test/scoped-dir'}])
     const scopedModule = baseModule.require('scoped-module')
 
     assert.strictEqual(scopedModule.scopedFunction(), 'scopedString')
   })
 
   it('must support relative dirs in the first require', function () {
-    const baseModule = scopedRequire(['./test/scoped-dir'])
+    const baseModule = scopedRequire([{path: './test/scoped-dir'}])
     const scopedModule = baseModule.require('./scoped-module')
 
     assert.strictEqual(scopedModule.scopedFunction(), 'scopedString')
   })
 
   it('must enable a module in a scoped dir to also be scoped to that dir', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
 
     const scopedModule = baseModule.require('scoped-module-that-imports')
 
@@ -42,7 +42,7 @@ describe('scoped-require node module', function () {
   })
 
   it('must enable a module in a scoped dir to use relative dir module loading', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
 
     const scopedModule = baseModule.require('scoped-module-that-imports-relatively')
 
@@ -50,8 +50,8 @@ describe('scoped-require node module', function () {
   })
 
   it('must enable more than one scoped baseModule', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
-    const baseModule2 = scopedRequire([path.resolve(__dirname, 'scoped-dir-2')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
+    const baseModule2 = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir-2')}])
 
     const scopedModule = baseModule.require('scoped-module')
     const scopedModule2 = baseModule2.require('scoped-module-2')
@@ -61,7 +61,7 @@ describe('scoped-require node module', function () {
   })
 
   it('must enable more than one scoped dir in a base module', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir'), path.resolve(__dirname, 'scoped-dir-2')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}, {path: path.resolve(__dirname, 'scoped-dir-2')}])
 
     const scopedModule = baseModule.require('scoped-module')
     const scopedModule2 = baseModule.require('scoped-module-2')
@@ -74,7 +74,7 @@ describe('scoped-require node module', function () {
 
   it('must allow deleting the scoped dir cache', function () {
     global.moduleLoadSideEffect = 1
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
     baseModule.require('module-whose-load-side-effects')
 
     assert.strictEqual(global.moduleLoadSideEffect, 2)
@@ -92,7 +92,7 @@ describe('scoped-require node module', function () {
 
   it('deleting scoped-dir cache will delete also submodules', function () {
     global.moduleLoadSideEffect = 1
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
     baseModule.require('module-whose-submodule-load-side-effects')
 
     assert.strictEqual(global.moduleLoadSideEffect, 2)
@@ -109,7 +109,7 @@ describe('scoped-require node module', function () {
   })
 
   it('ignore native modules when clearing cache', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, '../')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, '../')}])
     const hello = baseModule.require('native-hello-world')
 
     assert.strictEqual(hello(), 'Hello, world!')
@@ -125,7 +125,7 @@ describe('scoped-require node module', function () {
 
   it('deleting scoped-dir cache that includes circular-reference modules', function () {
     global.moduleLoadSideEffect = 1
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
     baseModule.require('module-with-circular-reference-submodules')
 
     assert.strictEqual(global.moduleLoadSideEffect, 2)
@@ -143,7 +143,7 @@ describe('scoped-require node module', function () {
 
   it('auto-deleting modules from cache', function () {
     global.moduleLoadSideEffect = 1
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')], {autoDeleteCache: true})
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}], {autoDeleteCache: true})
     baseModule.require('module-whose-load-side-effects-2')
 
     assert.strictEqual(global.moduleLoadSideEffect, 2)
@@ -158,14 +158,14 @@ describe('scoped-require node module', function () {
   })
 
   it('must enable evaluation of code in the context of the required scope', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
     const moduleExports = baseModule.loadCodeAsModule("exports.result = require('scoped-module').scopedFunction()")
 
     assert.strictEqual(moduleExports.result, 'scopedString')
   })
 
   it('must cache evaluated code if given filename', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
 
     const codeWithSideEffect = "global.moduleLoadSideEffect3 = (global.moduleLoadSideEffect3 || 0) + 1; require('module-whose-load-side-effects-3');"
     const codeWithSideEffect2 = "global.moduleLoadSideEffect3 = (global.moduleLoadSideEffect3 || 0) + 2; require('module-whose-load-side-effects-3');"
@@ -186,7 +186,7 @@ describe('scoped-require node module', function () {
   })
 
   it('must not cache evaluated code if autoDeleteCache', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')], {autoDeleteCache: true})
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}], {autoDeleteCache: true})
 
     const codeWithSideEffect = "global.moduleLoadSideEffect4 = (global.moduleLoadSideEffect4 || 0) + 1; require('module-whose-load-side-effects-4');"
     const codeWithSideEffect2 = "global.moduleLoadSideEffect4 = (global.moduleLoadSideEffect4 || 0) + 2; require('module-whose-load-side-effects-4');"
@@ -201,13 +201,13 @@ describe('scoped-require node module', function () {
   })
 
   it('must return the scopedDirs it received', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}])
 
     assert.deepEqual(baseModule.scopedDirs, [path.resolve(__dirname, 'scoped-dir')])
   })
 
   it('favors original node paths over scoped paths', () => {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir-3'), path.resolve(__dirname, 'scoped-dir-3', 'node_modules')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir-3')}, {path: path.resolve(__dirname, 'scoped-dir-3', 'node_modules')}])
 
     const scopedModule = baseModule.require('module1')
 
@@ -215,7 +215,7 @@ describe('scoped-require node module', function () {
   })
 
   it('must include and use first required module of the same name', function () {
-    const baseModule = scopedRequire([path.resolve(__dirname, 'dir1'), path.resolve(__dirname, 'dir2')])
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'dir1')}, {path: path.resolve(__dirname, 'dir2')}])
 
     const scopedModule = baseModule.require('scoped-test-module')
     assert.strictEqual(scopedModule.scopedFunction(), 'scoped dir 1')

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,34 @@ describe('scoped-require node module', function () {
     assert.strictEqual(global.moduleLoadSideEffect, 3)
   })
 
+  it('does not delete from cache when "skipCacheDelete" flag is true', function () {
+    global.moduleLoadSideEffect5 = 1
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir'), skipCacheDelete: true}])
+    baseModule.require('module-whose-load-side-effects-5')
+
+    assert.strictEqual(global.moduleLoadSideEffect5, 2)
+
+    baseModule.clearCache()
+
+    baseModule.require('module-whose-load-side-effects-5')
+
+    assert.strictEqual(global.moduleLoadSideEffect5, 2)
+  })
+
+  it('when 2 scoped dirs share a child and one of those doesn\'t have the "skipCacheDelete" flag - delete the cache', function () {
+    global.moduleLoadSideEffect6 = 1
+    const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir', 'a-nested-scoped-dir'), skipCacheDelete: true}, {path: path.resolve(__dirname, 'scoped-dir')}])
+    baseModule.require('module-whose-load-side-effects-6')
+
+    assert.strictEqual(global.moduleLoadSideEffect6, 2)
+
+    baseModule.clearCache()
+
+    baseModule.require('module-whose-load-side-effects-6')
+
+    assert.strictEqual(global.moduleLoadSideEffect6, 3)
+  })
+
   it('auto-deleting modules from cache', function () {
     global.moduleLoadSideEffect = 1
     const baseModule = scopedRequire([{path: path.resolve(__dirname, 'scoped-dir')}], {autoDeleteCache: true})


### PR DESCRIPTION
We want to support the ability for the user to decide which directories will be cleared from the cache when `clearCache` is called.
