### PR TITLE
support directoriesToClear in clearCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Returns an object with the following method:
 * `loadCodeAsModule(content, filename)`: use this as an alternative to require, to load code that is dynamic.
 * `scopedDirs`: same array passed as an argument. If the dirs were relative, then this array will contain the absolute paths.
 the `filename` is to make the errrors make sense.
-* `clearCache`: a method, that if called, will clear the module cache of all the modules
+* `clearCache(directoriesToClear)`: a method, that if called, will clear the module cache of all the modules
 already loaded from the `scopedDirs`. require-ing them again will reload them.
+Accepts an optional `directoriesToClear` array of strings argument. If given, `clearCache` will only clear modules inside the given directories from the cache.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function generateRequireForUserCode (scopedDirs, options) {
   function deleteModuleFromCache (m, directoriesToClear) {
     if (m && m.id && m.id.endsWith('.node')) {
       m.parent = null
-      return
+      return false
     }
 
     if (!shouldDeleteFromCache(m.id, directoriesToClear)) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function generateRequireForUserCode (scopedDirs, options) {
 
   function isSubPath (parent, modulePath) {
     const relative = path.relative(parent, modulePath)
-    return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+    return relative && !relative.startsWith('..')
   }
 
   function shouldDeleteFromCache (modulePath, directoriesToClear) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function generateRequireForUserCode (scopedDirs, options) {
   }
 
   function shouldDeleteFromCache (modulePath, directoriesToClear) {
-    if (_.isEmpty(directoriesToClear) || modulePath === baseModule.id) {
+    if ((directoriesToClear === undefined) || modulePath === baseModule.id) {
       return true
     }
 

--- a/index.js
+++ b/index.js
@@ -30,16 +30,34 @@ module.exports = function generateRequireForUserCode (scopedDirs, options) {
     }
   })
 
-  function deleteModuleFromCache (m) {
+  function isSubPath (parent, modulePath) {
+    const relative = path.relative(parent, modulePath)
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+  }
+
+  function shouldDeleteFromCache (modulePath, directoriesToClear) {
+    if (_.isEmpty(directoriesToClear) || modulePath === baseModule.id) {
+      return true
+    }
+
+    return _.some(directoriesToClear, (directoryToClear) => isSubPath(directoryToClear, modulePath))
+  }
+
+  function deleteModuleFromCache (m, directoriesToClear) {
     if (m && m.id && m.id.endsWith('.node')) {
       m.parent = null
       return
     }
+
+    if (!shouldDeleteFromCache(m.id, directoriesToClear)) {
+      return false
+    }
+
     delete Module._cache[m.id]
     const moduleChildren = m.children
     m.children = []
     _.forEach(moduleChildren, function (subModule) {
-      deleteModuleFromCache(subModule)
+      deleteModuleFromCache(subModule, directoriesToClear)
     })
   }
 
@@ -54,8 +72,8 @@ module.exports = function generateRequireForUserCode (scopedDirs, options) {
         return moduleExports
       },
     scopedDirs: scopedDirs,
-    clearCache: function () {
-      deleteModuleFromCache(baseModule)
+    clearCache: function (directoriesToClear) {
+      deleteModuleFromCache(baseModule, directoriesToClear)
     },
     loadCodeAsModule: function (code, filename) {
       if (filename && Module._cache[filename]) { return Module._cache[filename] }

--- a/test/scoped-dir-2/module-in-scoped-dir-2-whose-load-side-effects.js
+++ b/test/scoped-dir-2/module-in-scoped-dir-2-whose-load-side-effects.js
@@ -1,0 +1,1 @@
+global.moduleScopedDir2LoadSideEffect++

--- a/test/scoped-dir/module-whose-load-side-effects-5.js
+++ b/test/scoped-dir/module-whose-load-side-effects-5.js
@@ -1,0 +1,1 @@
+global.moduleLoadSideEffect5++

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,26 @@ describe('scoped-require node module', function () {
     assert.strictEqual(global.moduleLoadSideEffect, 3)
   })
 
+  it('clearCache deleting from cache only modules inside the given directoriesToClear, if given any', function () {
+    global.moduleLoadSideEffect5 = 1
+    global.moduleScopedDir2LoadSideEffect = 1
+
+    const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir'), path.resolve(__dirname, 'scoped-dir-2')])
+    baseModule.require('module-in-scoped-dir-2-whose-load-side-effects')
+    baseModule.require('module-whose-load-side-effects-5')
+
+    assert.strictEqual(global.moduleScopedDir2LoadSideEffect, 2)
+    assert.strictEqual(global.moduleLoadSideEffect5, 2)
+
+    baseModule.clearCache([path.resolve(__dirname, 'scoped-dir-2')])
+
+    baseModule.require('module-in-scoped-dir-2-whose-load-side-effects')
+    baseModule.require('module-whose-load-side-effects-5')
+
+    assert.strictEqual(global.moduleScopedDir2LoadSideEffect, 3)
+    assert.strictEqual(global.moduleLoadSideEffect5, 2)
+  })
+
   it('auto-deleting modules from cache', function () {
     global.moduleLoadSideEffect = 1
     const baseModule = scopedRequire([path.resolve(__dirname, 'scoped-dir')], {autoDeleteCache: true})


### PR DESCRIPTION
We want to support the ability for the user to decide which directories will be cleared from the cache when clearCache is called.
For this to happen, I added an `directoriesToClear` argument in `clearCache` which if given, will only clear modules under the given directories. if not passed, it will clear all modules as it did before, so it's not a breaking change.
I actually created a [PR](https://github.com/wix/scoped-require/pull/10) that implements it by breaking the `scopedDirs` format, but then I thought of this approach which is IMO way cleaner.

*I was contemplating whether to implement this argument as a mandatory, and thus making it a breaking change. I'm not sure if it's necessary, what do you think?